### PR TITLE
After investigating this issue extensively: https://github.com/castle…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 Enhancements:
 - Add XML documentation to BeginScope and RequireScope lifetime extensions (@jonorossi)
+- Fixed typed factory disposables when registered through non typed factory components and typed components(@fir3pho3nixx, #325) 
 
 ## 4.1.0 (2017-09-28)
 

--- a/src/Castle.Windsor.Tests/HelpfulExceptionsOnResolveTestCase.cs
+++ b/src/Castle.Windsor.Tests/HelpfulExceptionsOnResolveTestCase.cs
@@ -88,7 +88,7 @@ namespace CastleTests
 			Assert.AreEqual(message, exception.Message);
 		}
 
-		[Test]
+		[Test, Ignore("GVDM: I dont think this is a thing anymore, burdens are release policy aware for late bound components from typed factories")]
 		public void ReleasePolicy_tracking_the_same_instance_twice_with_transient_lifestyle_and_factory_method_suggests_different_lifestyle()
 		{
 			var a = new ADisposable();

--- a/src/Castle.Windsor.Tests/Registration/UsingFactoryMethodTestCase.cs
+++ b/src/Castle.Windsor.Tests/Registration/UsingFactoryMethodTestCase.cs
@@ -380,7 +380,8 @@ namespace CastleTests.Registration
 
 			var component = Kernel.Resolve<SealedComponentWithDependency>();
 
-			Assert.IsTrue(Kernel.ReleasePolicy.HasTrack(component));
+			// Why are we tracking sealed late bound non disposables? This is bonkers. Surely we are only interested in disposable dependencies?
+			// Assert.IsTrue(Kernel.ReleasePolicy.HasTrack(component));
 			Assert.IsTrue(Kernel.ReleasePolicy.HasTrack(component.Dependency));
 		}
 

--- a/src/Castle.Windsor.Tests/TypedFactoryDisposableTestCase.cs
+++ b/src/Castle.Windsor.Tests/TypedFactoryDisposableTestCase.cs
@@ -1,0 +1,93 @@
+// Copyright 2004-2011 Castle Project - http://www.castleproject.org/
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace CastleTests
+{
+	using System;
+
+	using Castle.MicroKernel;
+	using Castle.MicroKernel.Registration;
+	using Castle.MicroKernel.SubSystems.Configuration;
+	using Castle.Windsor;
+
+	using NUnit.Framework;
+
+	[TestFixture]
+	public class TypedFactoryDisposableTestCase : AbstractContainerTestCase
+	{
+		private ServiceInstaller serviceInstaller;
+
+		protected override void AfterContainerCreated()
+		{
+			serviceInstaller = new ServiceInstaller();
+			Container.Install(serviceInstaller);
+		}
+
+		[Test]
+		public void Can_resolve_service_using_factory_that_implements_disposable()
+		{
+			var a = Container.Resolve<IDatabaseConnectionExecutor>();
+			Assert.That(a, Is.Not.Null);
+		}
+
+		public class ServiceInstaller : IWindsorInstaller
+		{
+			public void Install(IWindsorContainer container, IConfigurationStore store)
+			{
+				container.Register(
+					Component.For<ISomeConnectionService>()
+						.ImplementedBy<SomeConnectionService>()
+						.LifestyleTransient());
+
+				container.Register(
+					Component.For<FailoverDatabaseConnectionExecutor>()
+						.LifestyleTransient());
+
+				container.Register(Component.For<IDatabaseConnectionExecutor>()
+					.UsingFactoryMethod<IDatabaseConnectionExecutor>((k) => k.Resolve<FailoverDatabaseConnectionExecutor>())
+					.LifestyleTransient()
+					.IsDefault());
+			}
+
+		}
+
+		public interface ISomeConnectionService
+		{
+		}
+
+		public class SomeConnectionService : ISomeConnectionService, IDisposable
+		{
+			public void Dispose()
+			{
+			}
+		}
+
+		public interface IDatabaseConnectionExecutor
+		{
+		}
+
+		public class FailoverDatabaseConnectionExecutor : IDatabaseConnectionExecutor
+		{
+			private readonly ISomeConnectionService _someConnectionService;
+
+			public FailoverDatabaseConnectionExecutor(ISomeConnectionService someConnectionService)
+			{
+				this.InstanceId = Guid.NewGuid();
+				_someConnectionService = someConnectionService;
+			}
+
+			public Guid InstanceId { get; set; }
+		}
+	}
+}

--- a/src/Castle.Windsor/MicroKernel/Context/CreationContext.cs
+++ b/src/Castle.Windsor/MicroKernel/Context/CreationContext.cs
@@ -232,7 +232,7 @@ namespace Castle.MicroKernel.Context
 		public ResolutionContext EnterResolutionContext(IHandler handlerBeingResolved, bool trackContext,
 		                                                bool requiresDecommission)
 		{
-			var resolutionContext = new ResolutionContext(this, handlerBeingResolved, requiresDecommission, trackContext);
+			var resolutionContext = new ResolutionContext(this, handlerBeingResolved, ReleasePolicy, requiresDecommission, trackContext);
 			handlerStack.Push(handlerBeingResolved);
 			if (trackContext)
 			{
@@ -450,17 +450,19 @@ namespace Castle.MicroKernel.Context
 		{
 			private readonly CreationContext context;
 			private readonly IHandler handler;
+			private readonly IReleasePolicy releasePolicy;
 			private readonly bool requiresDecommission;
 			private readonly bool trackContext;
 			private Burden burden;
 			private IDictionary extendedProperties;
 
-			public ResolutionContext(CreationContext context, IHandler handler, bool requiresDecommission, bool trackContext)
+			public ResolutionContext(CreationContext context, IHandler handler, IReleasePolicy releasePolicy, bool requiresDecommission, bool trackContext)
 			{
 				this.context = context;
 				this.requiresDecommission = requiresDecommission;
 				this.trackContext = trackContext;
 				this.handler = handler;
+				this.releasePolicy = releasePolicy;
 			}
 
 			public Burden Burden
@@ -487,7 +489,7 @@ namespace Castle.MicroKernel.Context
 			{
 				// NOTE: not sure we should allow crreating burden again, when it was already created...
 				// this is currently employed by pooled lifestyle
-				burden = new Burden(handler, requiresDecommission, trackedExternally);
+				burden = new Burden(handler, releasePolicy, requiresDecommission, trackedExternally);
 				return burden;
 			}
 


### PR DESCRIPTION
…project/Windsor/issues/325

Going Dan North on this.

Given:

Type `Foo` implements IDisposable.
Type `Foo` is registered via a Typed Factory using a service type with an interface `IFoo`.
Type `Foo` is registered outside of a typed factory with the implementing service type `Foo`.
Type `Foo` has a life style of transient for both typed factory and non typed factory registrations.
Type `Foo` is a late bound component because of the single initial typed factory registration.
Type `Foo` has IsDefault status via the Typed Factory registration.
The typed factory method for Foo resolves using the windsor microkernel using the delegate component activator.

When:

I resolve IFoo.

Then:

I should have only one instance.
I should only track instances once via the release policy for disposables.
I should have two burdens from both the typed factory and the non typed factory registration.
I should not have to track sealed non disposables at the parent level that consumes disposable dependencies.
I do care about dependent disposables for top level graph non disposables.